### PR TITLE
Add test parameter

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -14,6 +14,7 @@ class Controller extends BaseController
   protected $mdata_id;
   protected $is_mms_msg;
   protected $campaign_id;
+  protected $is_test;
 
   public function __construct(Request $request, MobileCommons $mobile_commons)
   {
@@ -37,6 +38,10 @@ class Controller extends BaseController
 
     if ($request->input('campaign_id')) {
       $this->campaign_id = $request->input('campaign_id');
+    }
+
+    if ($request->input('is_test')) {
+      $this->is_test = $request->input('is_test');
     }
   }
 }

--- a/app/Http/Controllers/MobileCommonsController.php
+++ b/app/Http/Controllers/MobileCommonsController.php
@@ -43,12 +43,7 @@
         $matched_response = Message::determineOptInPath('default', $mdata_id);
       }
 
-      // @TODO - move to own function?
-      if ($this->is_test) {
-        return response()->json(array('success' => 'success'));
-      }
-
-      return $this->mobile_commons->sendMessage($matched_response, $this->phone);
+      return $this->mobile_commons->sendMessage($matched_response, $this->phone, $this->is_test);
     }
 
     /*

--- a/app/Http/Controllers/MobileCommonsController.php
+++ b/app/Http/Controllers/MobileCommonsController.php
@@ -43,6 +43,11 @@
         $matched_response = Message::determineOptInPath('default', $mdata_id);
       }
 
+      // @TODO - move to own function?
+      if ($this->is_test) {
+        return response()->json(array('success' => 'success'));
+      }
+
       return $this->mobile_commons->sendMessage($matched_response, $this->phone);
     }
 

--- a/app/Services/MobileCommons.php
+++ b/app/Services/MobileCommons.php
@@ -25,23 +25,25 @@ class MobileCommons
   /**
    * Send message to mobile commons
    */
-  public function sendMessage($opt_in_path, $phone)
+  public function sendMessage($opt_in_path, $phone, $test = FALSE)
   {
-    $username = env('MOBILE_COMMONS_USERNAME');
-    $password = env('MOBILE_COMMONS_PASSWORD');
+    if (!$test) {
+      $username = env('MOBILE_COMMONS_USERNAME');
+      $password = env('MOBILE_COMMONS_PASSWORD');
 
-    $response = $this->client->request('POST', 'profile_update',
-      [
-        'auth'  => [$username, $password],
-        'query' => [
-          'phone_number'   => $phone,
-          'opt_in_path_id' => $opt_in_path,
+      $response = $this->client->request('POST', 'profile_update',
+        [
+          'auth'  => [$username, $password],
+          'query' => [
+            'phone_number'   => $phone,
+            'opt_in_path_id' => $opt_in_path,
+          ]
         ]
-      ]
-    );
+      );
+    }
 
     $json_response = array(
-      'success' => self::isSuccessful($response),
+      'success' => (isset($response)) ? self::isSuccessful($response) : 'success',
       'opt_in_path' => $opt_in_path,
       'phone' => $phone,
     );


### PR DESCRIPTION
Track a `test` parameter in the incoming request. If that parameter is passed in the request, then the `sendMessage()` function won't make the call to mobile commons and send an actual message to the device. Instead, we just return a successful response so we can make sure the app is up and running. 
