### PR TITLE
Pull the short term respons on short term mdatas

### DIFF
--- a/app/Message.php
+++ b/app/Message.php
@@ -122,7 +122,7 @@
           return '196048';
         }
         else {
-          return $message->long_term;
+          return $message->short_term;
         }
       }
       elseif ($mdata_id == '12388') {


### PR DESCRIPTION
This PR updates some of the hard coded logic that determined what mData to pull a response from. It was pulling responses from the `long_term` column of the messages table in both cases. 
